### PR TITLE
Hal init addition

### DIFF
--- a/source/init_api.c
+++ b/source/init_api.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed-hal/init_api.h"
+
+void mbed_hal_init(void)
+{
+    // not used for frdm-k64f
+}


### PR DESCRIPTION
k64f does not require init at the moment, thus empty

@bogdanm 