### PR TITLE
Fix UART0 alternate pin mapping

### DIFF
--- a/source/PeripheralPins.c
+++ b/source/PeripheralPins.c
@@ -102,7 +102,7 @@ const PinMap PinMap_UART_RX[] = {
     {PTC3 , UART_1, 3},
     {PTC14, UART_4, 3},
     {PTD2 , UART_2, 3},
-    {PTC6 , UART_0, 3},
+    {PTD6 , UART_0, 3},
     {NC  ,  NC    , 0}
 };
 


### PR DESCRIPTION
Tried using UART0 alternate pin mapping to the Add-on RF module connection (J6), and discovered a likely typographical error. UART0 Rx maps to "PTD6" not "PTC6". The fix has been verified in a lab setup.
